### PR TITLE
Website: fake LDP containers and resources

### DIFF
--- a/website/src/pages/data/[container]/[resource].js
+++ b/website/src/pages/data/[container]/[resource].js
@@ -17,7 +17,6 @@ const ldpResource = (url, resource) => ({
 
 
 export async function get({ params, request }) {
-    console.log(params);
     return {
         body: JSON.stringify(ldpResource(
             request.url,
@@ -29,6 +28,7 @@ export async function get({ params, request }) {
 export function getStaticPaths () {
     let paths = [];
     for (const key of Object.keys(containers)) {
+			paths.push({ params: { container: key } })
         for (const resource of containers[key] ) {
             paths.push({ params: { container: key, resource: resource['apods:domainName'] } })
         }

--- a/website/src/pages/data/[container]/index.js
+++ b/website/src/pages/data/[container]/index.js
@@ -31,7 +31,7 @@ export async function get({ params, request }) {
 
 export function getStaticPaths () {
     return [ 
-        { params: { container: "pod-providers"} },
-        { params: { container: "trusted-apps"} }
+        { params: { container: "pod-providers" } },
+        { params: { container: "trusted-apps" } }
     ]
 }


### PR DESCRIPTION
Does not work when deploying the website statically, because it doesn't recognize the endpoints as JSON data, which creates error when fetching from frontend apps.