### PR TITLE
ChoosePodProvidersPage: use new Pod providers lists

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -9,11 +9,3 @@ EXTEND_ESLINT=true
 
 # TODO move all backend-related directories to /backend to avoid package conflicts
 SKIP_PREFLIGHT_CHECK=true
-
-# The physical location of the pod provider server. E.g. Paris, France or Berlin, Germany.
-# Used to show the location of the provider in the "Choose provider" list for logins/signups.
-POD_AREA=Local
-
-# Location used by dataServers.js activitypods baseUrl
-# (The location is an ldp container that stores a list of public PodProviders, trusted apps, ...)
-ACTIVITYPODS_COMMON_CONF_URL=https://data.activitypods.org/

--- a/frontend/src/config/dataServers.js
+++ b/frontend/src/config/dataServers.js
@@ -21,7 +21,14 @@ const dataServers = {
     uploadsContainer: '/semapps/file'
   },
   activitypods: {
-    baseUrl: process.env.ACTIVITYPODS_COMMON_CONF_URL || 'https://data.activitypods.org/',
+    baseUrl: 'https://activitypods.org/data/',
+    containers: {
+      activitypods: {
+        'apods:PodProvider': ['/pod-providers'],
+        'interop:Application': ['/trusted-apps']
+      }
+    },
+    void: false,
     noProxy: true // HTTP signature is not supported on that server
   }
 };

--- a/frontend/src/resources/TrustedApp.js
+++ b/frontend/src/resources/TrustedApp.js
@@ -1,6 +1,6 @@
 export default {
   dataModel: {
-    types: ['apods:TrustedApps'],
+    types: ['interop:Application'],
     list: {
       servers: ['activitypods'],
       fetchContainer: true

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -122,8 +122,8 @@ export const mulberry32 = (seed: number) => {
 
 export const localhostRegex = /(127\.0\.0\.[0-9]{1,3}|localhost|\[::1\])/;
 
-export const isLocalHostname = (hostname: string) => {
-  return new RegExp(`^${localhostRegex.source}$`).test(hostname);
+export const isLocalURL = (url: string) => {
+  return new RegExp(`^${localhostRegex.source}$`).test((new URL(url)).hostname);
 };
 
 export const isUri = (uri: string) => {
@@ -191,21 +191,20 @@ export const validateBaseUrl = (uri: string, allowAddHttp: boolean) => {
   }
 
   // The URL must have a TLD (eg. `.com`), unless it's localhost.
-  if (!/^.+\..+/.exec(url.hostname) && !isLocalHostname(url.hostname)) {
+  if (!/^.+\..+/.exec(url.hostname) && !isLocalURL(uri)) {
     return { error: 'app.validation.uri.no_tld' };
   }
 
   return { url, error };
 };
 
-export const localPodProviderObject = CONFIG.BACKEND_URL
-  ? {
-      type: 'apods:PodProvider',
-      'apods:area': process.env.POD_AREA,
-      'apods:locales': 'en',
-      'apods:domainName': new URL(CONFIG.BACKEND_URL).host
-    }
-  : undefined;
+export const localPodProviderObject = {
+  type: 'apods:PodProvider',
+  'apods:area': 'Local server',
+  'apods:locales': CONFIG.DEFAULT_LOCALE,
+  'apods:baseUrl': CONFIG.BACKEND_URL,
+  'apods:providedBy': CONFIG.INSTANCE_NAME
+};
 
 /**
  * Removes duplicate items from a list.


### PR DESCRIPTION
- Load data from https://activitypods.org/data/pod-providers
- Use new `apods:baseUrl` predicate which replace `apods:domainName`