### PR TITLE
Improve app installation flow

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -44,7 +44,6 @@ const LoginPage = () => (
   <LocalLoginPage
     allowUsername
     postSignupRedirect="/initialize"
-    postLoginRedirect="/authorize"
     additionalSignupValues={{ 'schema:knowsLanguage': CONFIG.DEFAULT_LOCALE }}
     passwordScorer={scorer}
   />

--- a/frontend/src/pages/AuthorizePage/AuthorizePageView.js
+++ b/frontend/src/pages/AuthorizePage/AuthorizePageView.js
@@ -1,12 +1,12 @@
 import React, { useEffect, useCallback, useState } from 'react';
-import { Link, useTranslate, useGetList } from 'react-admin';
+import { Link, useTranslate, useGetList, useNotify } from 'react-admin';
 import { Typography, Box, Chip, Button } from '@mui/material';
 import { useSearchParams } from 'react-router-dom';
 import makeStyles from '@mui/styles/makeStyles';
 import WarningIcon from '@mui/icons-material/Warning';
 import DoneIcon from '@mui/icons-material/Done';
 import { useCheckAuthenticated } from '@semapps/auth-provider';
-import { useOutbox } from '@semapps/activitypub-components';
+import { useOutbox, useInbox } from '@semapps/activitypub-components';
 import SimpleBox from '../../layout/SimpleBox';
 import useTrustedApps from '../../hooks/useTrustedApps';
 import useApplication from '../../hooks/useApplication';
@@ -55,9 +55,11 @@ const AuthorizePageView = () => {
   const [isInstalling, setIsInstalling] = useState(false);
   const [allowedAccessNeeds, setAllowedAccessNeeds] = useState();
   const outbox = useOutbox();
+  const inbox = useInbox();
   const translate = useTranslate();
   const trustedApps = useTrustedApps();
   const [searchParams] = useSearchParams();
+  const notify = useNotify();
   const { data: appRegistrations, isLoading } = useGetList('AppRegistration', { page: 1, perPage: Infinity });
   const redirectTo = searchParams.get('redirect');
   const clientId = searchParams.get('client_id');
@@ -85,28 +87,48 @@ const AuthorizePageView = () => {
   }, [redirectTo]);
 
   const installApp = useCallback(async () => {
-    setIsInstalling(true);
-    await outbox.post({
-      '@context': [
-        'https://www.w3.org/ns/activitystreams',
-        {
-          apods: 'http://activitypods.org/ns/core#',
-          'apods:acceptedAccessNeeds': {
-            '@type': '@id'
-          },
-          'apods:acceptedSpecialRights': {
-            '@type': '@id'
+    try {
+      setIsInstalling(true);
+
+      // Do not await to ensure we don't miss the activities below
+      outbox.post({
+        '@context': [
+          'https://www.w3.org/ns/activitystreams',
+          {
+            apods: 'http://activitypods.org/ns/core#',
+            'apods:acceptedAccessNeeds': {
+              '@type': '@id'
+            },
+            'apods:acceptedSpecialRights': {
+              '@type': '@id'
+            }
           }
-        }
-      ],
-      type: 'apods:Install',
-      actor: outbox.owner,
-      object: application.id,
-      'apods:acceptedAccessNeeds': allowedAccessNeeds.filter(a => !a.startsWith('apods:')),
-      'apods:acceptedSpecialRights': allowedAccessNeeds.filter(a => a.startsWith('apods:'))
-    });
-    accessApp();
-  }, [outbox, application, allowedAccessNeeds, accessApp, setIsInstalling]);
+        ],
+        type: 'apods:Install',
+        actor: outbox.owner,
+        object: application.id,
+        'apods:acceptedAccessNeeds': allowedAccessNeeds.filter(a => !a.startsWith('apods:')),
+        'apods:acceptedSpecialRights': allowedAccessNeeds.filter(a => a.startsWith('apods:'))
+      });
+
+      // TODO Allow to pass an object, and automatically dereference it, like on the @semapps/activitypub matchActivity util
+      const createRegistrationActivity = await outbox.awaitActivity(
+        activity => activity.type === 'Create' && activity.to === application.id
+      );
+
+      await inbox.awaitActivity(
+        activity =>
+          activity.type === 'Accept' &&
+          activity.actor === application.id &&
+          activity.object === createRegistrationActivity.id
+      );
+
+      accessApp();
+    } catch (e) {
+      setIsInstalling(false);
+      notify(`Error on app installation: ${e.message}`, { type: 'error' });
+    }
+  }, [outbox, inbox, notify, application, allowedAccessNeeds, accessApp, setIsInstalling]);
 
   // Once all data are loaded, either redirect to app or show authorization screen
   useEffect(() => {

--- a/frontend/src/pages/ProfileCreatePage/ProfileCreatePage.js
+++ b/frontend/src/pages/ProfileCreatePage/ProfileCreatePage.js
@@ -24,7 +24,6 @@ const ProfileCreatePage = () => {
   // Reload profile unless profile is created
   useEffect(() => {
     if (!identity?.profileData?.id) {
-      console.log('set interval', refetchIdentity);
       const intervalId = setInterval(refetchIdentity, 1000);
       return () => clearInterval(intervalId);
     }

--- a/frontend/src/pages/ProfileCreatePage/ProfileCreatePage.js
+++ b/frontend/src/pages/ProfileCreatePage/ProfileCreatePage.js
@@ -1,4 +1,4 @@
-import React, { useMemo, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { useGetIdentity, EditBase, useNotify, useRedirect } from 'react-admin';
 import { ThemeProvider } from '@mui/material';
 import { useSearchParams } from 'react-router-dom';
@@ -11,15 +11,6 @@ const ProfileCreatePage = () => {
   const redirect = useRedirect();
   const { data: identity, refetch: refetchIdentity } = useGetIdentity();
   const [searchParams] = useSearchParams();
-
-  const redirectPath = useMemo(() => {
-    const redirectUrl = searchParams.get('redirect');
-    const clientId = searchParams.get('client_id');
-    if (clientId) {
-      return `/authorize?redirect=${encodeURIComponent(redirectUrl)}&client_id=${encodeURIComponent(clientId)}`;
-    }
-    return redirectUrl || '/';
-  }, [searchParams]);
 
   // Reload profile unless profile is created
   useEffect(() => {
@@ -45,7 +36,7 @@ const ProfileCreatePage = () => {
               undoable: false
             });
             refetchIdentity();
-            redirect(redirectPath);
+            redirect(searchParams.get('redirect'));
           }
         }}
       >

--- a/packages/core/services/installation/sub-services/access-grants.js
+++ b/packages/core/services/installation/sub-services/access-grants.js
@@ -10,7 +10,8 @@ module.exports = {
         read: true
       }
     },
-    excludeFromMirror: true
+    excludeFromMirror: true,
+    activateTombstones: false
   },
   actions: {
     async getSpecialRights(ctx) {

--- a/packages/core/services/installation/sub-services/app-registrations.js
+++ b/packages/core/services/installation/sub-services/app-registrations.js
@@ -11,7 +11,8 @@ module.exports = {
         read: true
       }
     },
-    excludeFromMirror: true
+    excludeFromMirror: true,
+    activateTombstones: false
   },
   actions: {
     async getForApp(ctx) {

--- a/packages/core/services/installation/sub-services/data-grants.js
+++ b/packages/core/services/installation/sub-services/data-grants.js
@@ -11,7 +11,8 @@ module.exports = {
         read: true
       }
     },
-    excludeFromMirror: true
+    excludeFromMirror: true,
+    activateTombstones: false
   },
   dependencies: ['ldp', 'ldp.registry', 'pod'],
   actions: {

--- a/packages/core/services/jwk.js
+++ b/packages/core/services/jwk.js
@@ -47,10 +47,12 @@ module.exports = {
 
       const publicKey = await importJWK(this.publicJwk, this.settings.alg);
 
-      // Allow expired token to last one more month
-      const { payload } = await jwtVerify(token, publicKey, { clockTolerance: 2629800 });
-
-      return payload;
+      try {
+        const { payload } = await jwtVerify(token, publicKey);
+        return payload;
+      } catch (e) {
+        // Return nothing. It will trigger a 401 error.
+      }
     }
   }
 };

--- a/packages/core/services/oidc-provider/base-config.js
+++ b/packages/core/services/oidc-provider/base-config.js
@@ -40,6 +40,9 @@ module.exports = (settings, privateJwk) => ({
     dPoP: { enabled: true },
     introspection: { enabled: true },
     registration: { enabled: true },
+    // The /.oidc/auth/session/end endpoint is being called when you disconnect from the Pod provider
+    // It has the effect of destroying the session and grants of the logged user
+    // The code below automatically accept the global logout, to avoid showing an additional form to the user
     rpInitiatedLogout: {
       enabled: true,
       // Automatically submit the form
@@ -125,16 +128,22 @@ module.exports = (settings, privateJwk) => ({
   scopes: ['openid', 'profile', 'offline_access', 'webid'],
   subjectTypes: ['public'],
   ttl: {
-    AccessToken: 3600, // Increase ?
+    AccessToken: 3600,
     AuthorizationCode: 600,
     BackchannelAuthenticationRequest: 600,
     ClientCredentials: 600,
     DeviceCode: 600,
-    Grant: 1209600,
-    IdToken: 3600, // Increase ?
+    // Set a very short ttl so that, if the application is uninstalled, we will show the Authorization screen again
+    // Ideally the grant linked with the session should be revoked on uninstallation but we found no easy way to do that (except with a raw edition of the Redis DB)
+    // Community Solid Server use 14 days (1209600s) that is the same time as the session (they expire at the same time)
+    Grant: 30,
+    // Since we currently use ID tokens instead of Access tokens with DPOP, keep it active for one year.
+    // Community Solid Server use one hour (3600s) which is a g)ood default if it is used only to generate an access token
+    IdToken: 31536000,
     Interaction: 3600,
     RefreshToken: 86400,
-    Session: 1209600
+    // Keep session open for one year, like the ID token. On Community Solid Server, it is 14 days (1209600s)
+    Session: 31536000
   },
   renderError: async (ctx, out, error) => {
     console.error(error);

--- a/packages/core/services/oidc-provider/oidc-provider.js
+++ b/packages/core/services/oidc-provider/oidc-provider.js
@@ -64,9 +64,22 @@ module.exports = {
       }
     });
 
+    await this.broker.call('api.addRoute', {
+      route: {
+        name: 'oidc-consent-completed',
+        path: path.join(basePath, '/.oidc/consent-completed'),
+        bodyParsers: {
+          json: true
+        },
+        aliases: {
+          'POST /': 'oidc-provider.consentCompleted'
+        }
+      }
+    });
+
     // The OIDC provider route must be added after all other routes, otherwise it gets overwritten
     // TODO find out why ! Probably due to the fact it is only a middleware (adding dummy aliases doesn't help)
-    await delay(5000);
+    await delay(10000);
 
     await this.broker.call('api.addRoute', {
       route: {
@@ -126,6 +139,7 @@ module.exports = {
         throw new Error('Not found');
       }
     },
+    // See https://github.com/panva/node-oidc-provider/blob/main/docs/README.md#user-flows
     async loginCompleted(ctx) {
       const { interactionId, webId } = ctx.params;
 
@@ -134,8 +148,30 @@ module.exports = {
       }
 
       await this.interactionFinished(interactionId, {
-        login: { accountId: webId, amr: ['pwd'] }
+        login: { accountId: webId, amr: ['pwd'], remember: true }
       });
+    },
+    // See https://github.com/panva/node-oidc-provider/blob/main/docs/README.md#user-flows
+    async consentCompleted(ctx) {
+      const { interactionId } = ctx.params;
+      const interaction = await this.oidc.Interaction.find(interactionId);
+
+      if (interaction) {
+        const clientId = interaction.params?.client_id;
+        const accountId = interaction.session?.accountId;
+        const scope = interaction.params?.scope;
+
+        // Grant the requested scope (should be "webid openid")
+        const grant = new this.oidc.Grant({ accountId, clientId });
+        grant.addOIDCScope(scope);
+        const grantId = await grant.save();
+
+        await this.interactionFinished(interactionId, {
+          consent: { grantId }
+        });
+      } else {
+        throw new Error(`No interaction found with ID ${interactionId}`);
+      }
     }
   },
   events: {


### PR DESCRIPTION
Closes https://github.com/activitypods/activitypods/issues/270 
Closes #259

Requires https://github.com/assemblee-virtuelle/semapps/pull/1295 and https://github.com/assemblee-virtuelle/semapps/pull/1297 

- Wait for `Accept` activity from app on install and uninstall
- Fix node-oidc-provider Grant issue by letting it redirect to /authorize screen
- On app uninstall, remove the corresponding Grant so that the /authorize screen is shown again if the app is installed again
- If login is expired, remove the token and go to the login screen
- Increase ID token TTL to one year (this will be changed when we complete Solid-OIDC)
- Add some documentation on how we configured the OIDC provider