### PR TITLE
Update app, access needs and class descriptions when settings change

### DIFF
--- a/packages/app/mappings.js
+++ b/packages/app/mappings.js
@@ -1,0 +1,8 @@
+const necessityMapping = {
+  required: 'http://www.w3.org/ns/solid/interop#AccessRequired',
+  optional: 'http://www.w3.org/ns/solid/interop#AccessOptional'
+};
+
+module.exports = {
+  necessityMapping
+};

--- a/packages/app/service.js
+++ b/packages/app/service.js
@@ -100,10 +100,9 @@ module.exports = {
     this.broker.createService({ mixins: [TranslatorService] });
   },
   async started() {
-    this.appActor = await this.broker.call('actors.createOrUpdateApp', {
-      app: this.settings.app,
-      oidc: this.settings.oidc
-    });
+    const { app, oidc, accessNeeds, classDescriptions } = this.settings;
+
+    this.appActor = await this.broker.call('actors.createOrUpdateApp', { app, oidc });
 
     // TODO Ensure this doesn't add a link on every call
     await this.broker.call('nodeinfo.addLink', {
@@ -113,42 +112,13 @@ module.exports = {
 
     await this.broker.call('access-needs-groups.createOrUpdate', {
       accessNeeds: {
-        required: arrayOf(this.settings.accessNeeds.required),
-        optional: arrayOf(this.settings.accessNeeds.optional)
+        // Ensure we have one key per necessity, otherwise we may fail to delete unused access needs
+        required: arrayOf(accessNeeds.required),
+        optional: arrayOf(accessNeeds.optional)
       }
     });
 
-    // for (const [type, classDescription] of Object.entries(this.settings.classDescriptions)) {
-    //   // Create one ClassDescription per language
-    //   const results = await this.broker.call('class-descriptions.register', {
-    //     type,
-    //     appUri: this.appActor.id,
-    //     label: classDescription.label,
-    //     labelPredicate: classDescription.labelPredicate,
-    //     openEndpoint: classDescription.openEndpoint
-    //   });
-
-    //   for (const [locale, classDescriptionUri] of Object.entries(results)) {
-    //     // Attach ClassDescription to corresponding AccessDescriptionSet (create it if necessary)
-    //     const accessDescriptionSetUri = await this.broker.call('access-description-sets.attachClassDescription', {
-    //       locale,
-    //       classDescriptionUri
-    //     });
-
-    //     // Attach the AccessDescriptionSet to the Application
-    //     await this.broker.call('ldp.resource.patch', {
-    //       resourceUri: this.appActor.id,
-    //       triplesToAdd: [
-    //         triple(
-    //           namedNode(this.appActor.id),
-    //           namedNode('http://www.w3.org/ns/solid/interop#hasAccessDescriptionSet'),
-    //           namedNode(accessDescriptionSetUri)
-    //         )
-    //       ],
-    //       webId: 'system'
-    //     });
-    //   }
-    // }
+    await this.broker.call('access-description-sets.createOrUpdate', { classDescriptions, appUri: this.appActor.id });
   },
   actions: {
     get() {

--- a/packages/app/services/registration/access-description-sets.js
+++ b/packages/app/services/registration/access-description-sets.js
@@ -1,6 +1,6 @@
-const { ControlledContainerMixin } = require('@semapps/ldp');
-const { triple, namedNode } = require('@rdfjs/data-model');
+const { ControlledContainerMixin, arrayOf } = require('@semapps/ldp');
 const { MIME_TYPES } = require('@semapps/mime-types');
+const { arraysEqual } = require('../../utils');
 
 module.exports = {
   name: 'access-description-sets',
@@ -8,43 +8,138 @@ module.exports = {
   settings: {
     acceptedTypes: ['interop:AccessDescriptionSet'],
     readOnly: true,
-    excludeFromMirror: true
+    excludeFromMirror: true,
+    activateTombstones: false
   },
   actions: {
-    async attachClassDescription(ctx) {
-      const { locale, classDescriptionUri } = ctx.params;
-      const descriptionSet = await this.actions.findByLocale({ locale }, { parentCtx: ctx });
+    put() {
+      throw new Error(`The resources of type interop:AccessDescriptionSet are immutable`);
+    },
+    patch() {
+      throw new Error(`The resources of type interop:AccessDescriptionSet are immutable`);
+    },
+    async createOrUpdate(ctx) {
+      const { classDescriptions, appUri } = ctx.params;
+      const app = await ctx.call('ldp.resource.get', { resourceUri: appUri, accept: MIME_TYPES.JSON });
+      let classDescriptionsByLocale = {};
 
-      if (descriptionSet) {
-        await ctx.call('access-description-sets.patch', {
-          resourceUri: descriptionSet.id,
-          triplesToAdd: [
-            triple(
-              namedNode(descriptionSet.id),
-              namedNode('http://activitypods.org/ns/core#hasClassDescription'),
-              namedNode(classDescriptionUri)
-            )
-          ],
-          webId: 'system'
+      /*
+       * Create all the class descriptions
+       * If the class description has not changed, we simply get its URI
+       * If the class description changed, we recreate it as it must be immutable
+       */
+      for (const [type, classDescription] of Object.entries(classDescriptions)) {
+        const [expandedType] = await ctx.call('jsonld.parser.expandTypes', { types: [type] });
+        const [expandedLabelPredicate] = await ctx.call('jsonld.parser.expandTypes', {
+          types: [classDescription.labelPredicate]
         });
-        return descriptionSet.id;
-      } else {
-        const accessDescriptionSetUri = await ctx.call('access-description-sets.post', {
-          resource: {
-            type: 'interop:AccessDescriptionSet',
-            'interop:usesLanguage': locale,
-            'apods:hasClassDescription': classDescriptionUri
+
+        for (const locale of Object.keys(classDescription.label)) {
+          const existingClassDescriptionUri = await ctx.call('class-descriptions.findExisting', {
+            locale,
+            type: expandedType,
+            label: classDescription.label[locale],
+            labelPredicate: expandedLabelPredicate,
+            openEndpoint: classDescription.openEndpoint,
+            icon: classDescription.icon || app['oidc:logo_uri']
+          });
+
+          if (existingClassDescriptionUri) {
+            if (!classDescriptionsByLocale[locale]) classDescriptionsByLocale[locale] = [];
+            classDescriptionsByLocale[locale].push(existingClassDescriptionUri);
+          } else {
+            const classDescriptionUri = await ctx.call('class-descriptions.post', {
+              resource: {
+                type: 'apods:ClassDescription',
+                'apods:describedClass': expandedType,
+                'apods:describedBy': appUri,
+                'skos:prefLabel': classDescription.label[locale],
+                'apods:labelPredicate': expandedLabelPredicate,
+                'apods:openEndpoint': classDescription.openEndpoint,
+                'apods:icon': classDescription.icon || app['oidc:logo_uri']
+              },
+              contentType: MIME_TYPES.JSON,
+              webId: 'system'
+            });
+            if (!classDescriptionsByLocale[locale]) classDescriptionsByLocale[locale] = [];
+            classDescriptionsByLocale[locale].push(classDescriptionUri);
+          }
+        }
+      }
+
+      /**
+       * Now we have created all the class descriptions, put them in the corresponding access description sets
+       */
+
+      const existingSetsByLocale = await this.actions.findExistingByLocale({}, { parentCtx: ctx });
+
+      for (const [locale, classDescriptionUris] of Object.entries(classDescriptionsByLocale)) {
+        const existingSet = existingSetsByLocale[locale];
+
+        if (existingSet) {
+          if (arraysEqual(existingSet['apods:hasClassDescription'], classDescriptionUris)) {
+            continue;
+          } else {
+            this.logger.info(`Deleting access description set ${existingSet.id} as it must be recreated.`);
+            await this.actions.delete({ resourceUri: existingSet.id, webId: 'system' });
+
+            const classDescriptionsToDelete = arrayOf(existingSet['apods:hasClassDescription']).filter(
+              uri => !classDescriptionUris.includes(uri)
+            );
+            for (const uri of classDescriptionsToDelete) {
+              this.logger.info(`Deleting class description ${uri} as it has been modified or removed.`);
+              await ctx.call('class-descriptions.delete', { resourceUri: uri, webId: 'system' });
+            }
+          }
+        }
+
+        const setUri = await this.actions.post(
+          {
+            resource: {
+              type: 'interop:AccessDescriptionSet',
+              'interop:usesLanguage': locale,
+              'apods:hasClassDescription': classDescriptionUris
+            },
+            contentType: MIME_TYPES.JSON,
+            webId: 'system'
           },
-          contentType: MIME_TYPES.JSON,
-          webId: 'system'
-        });
-        return accessDescriptionSetUri;
+          { parentCtx: ctx }
+        );
+
+        this.logger.info(`Created new access description set ${setUri}`);
+      }
+
+      /*
+       * Delete orphan access descriptions sets
+       */
+
+      for (const [locale, existingSet] of Object.entries(existingSetsByLocale)) {
+        if (!classDescriptionsByLocale[locale]) {
+          this.logger.info(`Deleting access description set ${existingSet.id} as locale has been removed.`);
+          await this.actions.delete({ resourceUri: existingSet.id, webId: 'system' });
+
+          for (const uri of arrayOf(existingSet['apods:hasClassDescription'])) {
+            this.logger.info(`Deleting class description ${uri} as locale has been removed.`);
+            await ctx.call('class-descriptions.delete', { resourceUri: uri, webId: 'system' });
+          }
+        }
       }
     },
-    async findByLocale(ctx) {
-      const { locale, webId } = ctx.params;
-      const descriptionSets = await this.actions.list({ webId }, { parentCtx: ctx });
-      return descriptionSets['ldp:contains']?.find(set => set['interop:usesLanguage'] === locale);
+    async findExistingByLocale(ctx) {
+      const descriptionSets = await this.actions.list({}, { parentCtx: ctx });
+      return Object.fromEntries(descriptionSets['ldp:contains']?.map(set => [set['interop:usesLanguage'], set]));
+    }
+  },
+  hooks: {
+    after: {
+      async post(ctx, res) {
+        await ctx.call('actors.attachAccessDescriptionSet', { accessDescriptionSetUri: res });
+        return res;
+      },
+      async delete(ctx, res) {
+        await ctx.call('actors.detachAccessDescriptionSet', { accessDescriptionSetUri: ctx.params.resourceUri });
+        return res;
+      }
     }
   }
 };

--- a/packages/app/services/registration/access-grants.js
+++ b/packages/app/services/registration/access-grants.js
@@ -1,5 +1,8 @@
 const { ControlledContainerMixin } = require('@semapps/ldp');
 
+/**
+ * Mirror container for access grants which have been granted to the app
+ */
 module.exports = {
   name: 'access-grants',
   mixins: [ControlledContainerMixin],

--- a/packages/app/services/registration/access-needs-groups.js
+++ b/packages/app/services/registration/access-needs-groups.js
@@ -15,10 +15,10 @@ module.exports = {
   },
   actions: {
     put() {
-      throw new Error(`The resource of type interop:AccessNeedGroup are immutable`);
+      throw new Error(`The resources of type interop:AccessNeedGroup are immutable`);
     },
     patch() {
-      throw new Error(`The resource of type interop:AccessNeedGroup are immutable`);
+      throw new Error(`The resources of type interop:AccessNeedGroup are immutable`);
     },
     async createOrUpdate(ctx) {
       const { accessNeeds: accessNeedsByNecessity } = ctx.params;
@@ -106,7 +106,7 @@ module.exports = {
               );
             }
 
-            await this.actions.post(
+            const accessNeedGroupUri = await this.actions.post(
               {
                 resource: {
                   '@context': interopContext,
@@ -124,6 +124,8 @@ module.exports = {
                 parentCtx: ctx
               }
             );
+
+            this.logger.info(`Created new access need group ${accessNeedGroupUri}`);
           }
         } else {
           // If there are no more access needs...

--- a/packages/app/services/registration/access-needs-groups.js
+++ b/packages/app/services/registration/access-needs-groups.js
@@ -1,65 +1,121 @@
-const { ControlledContainerMixin } = require('@semapps/ldp');
+const { ControlledContainerMixin, arrayOf } = require('@semapps/ldp');
 const { MIME_TYPES } = require('@semapps/mime-types');
 const { interopContext } = require('@activitypods/core');
+const { arraysEqual } = require('../../utils');
+const { necessityMapping } = require('../../mappings');
 
 module.exports = {
   name: 'access-needs-groups',
   mixins: [ControlledContainerMixin],
   settings: {
-    accessNeeds: {
-      required: [],
-      optional: []
-    },
     // ControlledContainerMixin settings
     acceptedTypes: ['interop:AccessNeedGroup'],
-    readOnly: true
+    readOnly: true,
+    activateTombstones: false
   },
   actions: {
-    async initialize(ctx) {
-      let accessNeedGroupUris = [];
+    put() {
+      throw new Error(`The resource of type interop:AccessNeedGroup are immutable`);
+    },
+    patch() {
+      throw new Error(`The resource of type interop:AccessNeedGroup are immutable`);
+    },
+    async createOrUpdate(ctx) {
+      const { accessNeeds: accessNeedsByNecessity } = ctx.params;
 
-      for (const [necessity, accessNeeds] of Object.entries(this.settings.accessNeeds)) {
-        let accessNeedsUris = [],
-          specialRights = [];
+      for (const [necessity, accessNeeds] of Object.entries(accessNeedsByNecessity)) {
+        let newAccessNeedsUris = [];
+
+        const existingAccessNeedGroup = await this.actions.findByNecessity({ necessity });
 
         if (accessNeeds.length > 0) {
-          for (const accessNeed of accessNeeds) {
-            if (typeof accessNeed === 'string') {
-              // If a string is provided, we have a special access need (e.g. apods:ReadInbox)
-              specialRights.push(accessNeed);
+          /*
+           * PARSE SPECIAL RIGHTS
+           */
+          // TODO Ensure the special right is valid
+          const newSpecialRights = accessNeeds.filter(a => typeof a === 'string');
+          const haveSpecialRightsChanged = !arraysEqual(
+            newSpecialRights,
+            existingAccessNeedGroup?.['apods:hasSpecialRights']
+          );
+
+          /*
+           * GO THROUGH NEW ACCESS NEEDS AND CREATE THEM IF NECESSARY
+           */
+          let haveAccessNeedsChanged = false;
+
+          for (const accessNeed of accessNeeds.filter(a => typeof a !== 'string')) {
+            const [registeredClassUri] = await ctx.call('jsonld.parser.expandTypes', {
+              types: [accessNeed.registeredClass]
+            });
+
+            const existingAccessNeed = await ctx.call('access-needs.find', {
+              necessity,
+              registeredClassUri,
+              accessMode: accessNeed.accessMode
+            });
+
+            if (existingAccessNeed) {
+              this.logger.info(`Keeping access need ${existingAccessNeed.id} as it has not been changed.`);
+              newAccessNeedsUris.push(existingAccessNeed.id);
             } else {
-              const registeredClassFullUri = await ctx.call('jsonld.parser.expandTypes', {
-                types: [accessNeed.registeredClass]
+              haveAccessNeedsChanged = true;
+              const newAccessNeedUri = await ctx.call('access-needs.post', {
+                resource: {
+                  '@context': interopContext,
+                  '@type': 'interop:AccessNeed',
+                  'interop:accessNecessity': necessityMapping[necessity],
+                  'interop:accessMode': accessNeed.accessMode,
+                  'apods:registeredClass': registeredClassUri
+                },
+                contentType: MIME_TYPES.JSON,
+                webId: 'system'
               });
-              accessNeedsUris.push(
-                await ctx.call('access-needs.post', {
-                  resource: {
-                    '@context': interopContext,
-                    '@type': 'interop:AccessNeed',
-                    'interop:accessNecessity':
-                      necessity === 'required' ? 'interop:AccessRequired' : 'interop:AccessOptional',
-                    'interop:accessMode': accessNeed.accessMode,
-                    'apods:registeredClass': registeredClassFullUri
-                  },
-                  contentType: MIME_TYPES.JSON,
-                  webId: 'system'
-                })
-              );
+              this.logger.info(`Created new access need ${newAccessNeedUri}`);
+              newAccessNeedsUris.push(newAccessNeedUri);
             }
           }
 
-          accessNeedGroupUris.push(
+          /*
+           * DELETE EXISTING ACCESS NEEDS THAT ARE NOT IN THE NEW LIST
+           */
+          if (existingAccessNeedGroup) {
+            const accessNeedsToDelete = arrayOf(existingAccessNeedGroup['interop:hasAccessNeed']).filter(
+              uri => !newAccessNeedsUris.includes(uri)
+            );
+            if (accessNeedsToDelete.length > 0) {
+              haveAccessNeedsChanged = true;
+              for (const uri of accessNeedsToDelete) {
+                this.logger.info(`Deleting access need ${uri} as it has been modified or removed.`);
+                await ctx.call('access-needs.delete', { resourceUri: uri, webId: 'system' });
+              }
+            }
+          }
+
+          /*
+           * CREATE A NEW ACCESS NEED GROUP IF IT HAS CHANGED
+           */
+          if (haveSpecialRightsChanged || haveAccessNeedsChanged) {
+            this.logger.info(`The ${necessity} access needs and/or special rights have changed.`);
+
+            if (existingAccessNeedGroup) {
+              this.logger.info(`Deleting access need group ${existingAccessNeedGroup.id} as it must be recreated.`);
+              await this.actions.delete(
+                { resourceUri: existingAccessNeedGroup.id, webId: 'system' },
+                { parentCtx: ctx }
+              );
+            }
+
             await this.actions.post(
               {
                 resource: {
                   '@context': interopContext,
                   '@type': 'interop:AccessNeedGroup',
-                  'interop:accessNecessity':
-                    necessity === 'required' ? 'interop:AccessRequired' : 'interop:AccessOptional',
+                  'interop:accessNecessity': necessityMapping[necessity],
                   'interop:accessScenario': 'interop:PersonalAccess',
                   'interop:authenticatedAs': 'interop:SocialAgent',
-                  'interop:hasAccessNeed': accessNeedsUris,
-                  'apods:hasSpecialRights': specialRights
+                  'interop:hasAccessNeed': newAccessNeedsUris,
+                  'apods:hasSpecialRights': newSpecialRights
                 },
                 contentType: MIME_TYPES.JSON,
                 webId: 'system'
@@ -67,12 +123,49 @@ module.exports = {
               {
                 parentCtx: ctx
               }
-            )
-          );
+            );
+          }
+        } else {
+          // If there are no more access needs...
+          if (existingAccessNeedGroup) {
+            this.logger.info(
+              `Deleting access need group ${existingAccessNeedGroup.id} as there are no more ${necessity} access needs`
+            );
+            await this.actions.delete({ resourceUri: existingAccessNeedGroup.id, webId: 'system' }, { parentCtx: ctx });
+            for (const accessNeedUri of arrayOf(existingAccessNeedGroup['interop:hasAccessNeed'])) {
+              this.logger.info(`Deleting related access need ${accessNeedUri}`);
+              await ctx.call('access-needs.delete', { resourceUri: accessNeedUri, webId: 'system' });
+            }
+          }
         }
       }
+    },
+    async findByNecessity(ctx) {
+      const { necessity } = ctx.params;
 
-      return accessNeedGroupUris;
+      const filteredContainer = await this.actions.list(
+        {
+          filters: {
+            'http://www.w3.org/ns/solid/interop#accessNecessity': necessityMapping[necessity]
+          },
+          webId: 'system'
+        },
+        { parentCtx: ctx }
+      );
+
+      return filteredContainer['ldp:contains']?.[0];
+    }
+  },
+  hooks: {
+    after: {
+      async post(ctx, res) {
+        await ctx.call('actors.attachAccessNeedGroup', { accessNeedGroupUri: res });
+        return res;
+      },
+      async delete(ctx, res) {
+        await ctx.call('actors.detachAccessNeedGroup', { accessNeedGroupUri: ctx.params.resourceUri });
+        return res;
+      }
     }
   }
 };

--- a/packages/app/services/registration/access-needs.js
+++ b/packages/app/services/registration/access-needs.js
@@ -1,10 +1,37 @@
-const { ControlledContainerMixin } = require('@semapps/ldp');
+const { ControlledContainerMixin, arrayOf } = require('@semapps/ldp');
+const { necessityMapping } = require('../../mappings');
+const { arraysEqual } = require('../../utils');
 
 module.exports = {
   name: 'access-needs',
   mixins: [ControlledContainerMixin],
   settings: {
     acceptedTypes: ['interop:AccessNeed'],
-    readOnly: true
+    readOnly: true,
+    activateTombstones: false
+  },
+  actions: {
+    put() {
+      throw new Error(`The resource of type interop:AccessNeed are immutable`);
+    },
+    patch() {
+      throw new Error(`The resource of type interop:AccessNeed are immutable`);
+    },
+    async find(ctx) {
+      const { necessity, registeredClassUri, accessMode } = ctx.params;
+
+      const filteredContainer = await this.actions.list(
+        {
+          filters: {
+            'http://activitypods.org/ns/core#registeredClass': registeredClassUri,
+            'http://www.w3.org/ns/solid/interop#accessNecessity': necessityMapping[necessity]
+          },
+          webId: 'system'
+        },
+        { parentCtx: ctx }
+      );
+
+      return filteredContainer['ldp:contains']?.find(a => arraysEqual(a['interop:accessMode'], accessMode));
+    }
   }
 };

--- a/packages/app/services/registration/access-needs.js
+++ b/packages/app/services/registration/access-needs.js
@@ -1,4 +1,4 @@
-const { ControlledContainerMixin, arrayOf } = require('@semapps/ldp');
+const { ControlledContainerMixin } = require('@semapps/ldp');
 const { necessityMapping } = require('../../mappings');
 const { arraysEqual } = require('../../utils');
 
@@ -12,10 +12,10 @@ module.exports = {
   },
   actions: {
     put() {
-      throw new Error(`The resource of type interop:AccessNeed are immutable`);
+      throw new Error(`The resources of type interop:AccessNeed are immutable`);
     },
     patch() {
-      throw new Error(`The resource of type interop:AccessNeed are immutable`);
+      throw new Error(`The resources of type interop:AccessNeed are immutable`);
     },
     async find(ctx) {
       const { necessity, registeredClassUri, accessMode } = ctx.params;

--- a/packages/app/services/registration/actors.js
+++ b/packages/app/services/registration/actors.js
@@ -1,5 +1,8 @@
+const { triple, namedNode } = require('@rdfjs/data-model');
 const { ControlledContainerMixin, DereferenceMixin } = require('@semapps/ldp');
+const { MIME_TYPES } = require('@semapps/mime-types');
 const { ACTOR_TYPES } = require('@semapps/activitypub');
+const { interopContext } = require('@activitypods/core');
 
 module.exports = {
   name: 'actors',
@@ -9,5 +12,145 @@ module.exports = {
     acceptedTypes: [ACTOR_TYPES.APPLICATION, 'interop:Application'],
     readOnly: true,
     dereferencePlan: [{ property: 'publicKey' }, { property: 'assertionMethod' }]
+  },
+  actions: {
+    async createOrUpdateApp(ctx) {
+      const { app, oidc } = ctx.params;
+
+      const actorAccount = await ctx.call('auth.account.findByUsername', { username: 'app' });
+      let actorUri = actorAccount?.webId;
+      const actorExist = actorUri && (await ctx.call('ldp.resource.exist', { resourceUri: actorUri }));
+
+      if (!actorExist) {
+        this.logger.info(`Actor ${actorUri} does not exist yet, creating it...`);
+
+        const account = await ctx.call(
+          'auth.account.create',
+          {
+            username: 'app'
+          },
+          { meta: { isSystemCall: true } }
+        );
+
+        try {
+          actorUri = await this.actions.post(
+            {
+              slug: 'app',
+              resource: {
+                '@context': ['https://www.w3.org/ns/activitystreams', interopContext],
+                type: [ACTOR_TYPES.APPLICATION, 'interop:Application'],
+                preferredUsername: 'app',
+                name: app.name,
+                'interop:applicationName': app.name,
+                'interop:applicationDescription': app.description,
+                'interop:applicationAuthor': app.author,
+                'interop:applicationThumbnail': app.thumbnail,
+                'oidc:client_name': app.name,
+                'oidc:redirect_uris': oidc.redirectUris,
+                'oidc:post_logout_redirect_uris': oidc.postLogoutRedirectUris,
+                'oidc:client_uri': oidc.clientUri,
+                'oidc:logo_uri': app.thumbnail,
+                'oidc:tos_uri': oidc.tosUri,
+                'oidc:scope': 'openid profile offline_access webid',
+                'oidc:grant_types': ['refresh_token', 'authorization_code'],
+                'oidc:response_types': ['code'],
+                'oidc:default_max_age': 3600,
+                'oidc:require_auth_time': true
+              },
+              contentType: MIME_TYPES.JSON,
+              webId: 'system'
+            },
+            { parentCtx: ctx }
+          );
+
+          await ctx.call(
+            'auth.account.attachWebId',
+            {
+              accountUri: account['@id'],
+              webId: actorUri
+            },
+            { meta: { isSystemCall: true } }
+          );
+        } catch (e) {
+          // Delete account if resource creation failed, or it may cause problems when retrying
+          await ctx.call('auth.account.remove', { id: account['@id'] });
+          throw e;
+        }
+      } else {
+        this.logger.info(`Actor ${actorUri} exists already, updating it...`);
+
+        const actor = await this.actions.get(
+          {
+            resourceUri: actorUri,
+            accept: MIME_TYPES.JSON,
+            webId: 'system'
+          },
+          { parentCtx: ctx }
+        );
+
+        // Only update the settings which may have changed
+        await this.actions.put(
+          {
+            resource: {
+              ...actor,
+              name: app.name,
+              'interop:applicationName': app.name,
+              'interop:applicationDescription': app.description,
+              'interop:applicationAuthor': app.author,
+              'interop:applicationThumbnail': app.thumbnail,
+              'oidc:client_name': app.name,
+              'oidc:redirect_uris': oidc.redirectUris,
+              'oidc:post_logout_redirect_uris': oidc.postLogoutRedirectUris,
+              'oidc:client_uri': oidc.clientUri,
+              'oidc:logo_uri': app.thumbnail,
+              'oidc:tos_uri': oidc.tosUri
+            },
+            contentType: MIME_TYPES.JSON,
+            webId: 'system'
+          },
+          { parentCtx: ctx }
+        );
+
+        // TODO Notify registered users to update the application in their cache (via Update activity)
+        // The activity should not be sent if the PUT triggers no changes
+      }
+
+      this.appActor = await ctx.call('activitypub.actor.awaitCreateComplete', { actorUri });
+      return this.appActor;
+    },
+    async attachAccessNeedGroup(ctx) {
+      const { accessNeedGroupUri } = ctx.params;
+      await this.actions.patch(
+        {
+          resourceUri: this.appActor.id,
+          triplesToAdd: [
+            triple(
+              namedNode(this.appActor.id),
+              namedNode('http://www.w3.org/ns/solid/interop#hasAccessNeedGroup'),
+              namedNode(accessNeedGroupUri)
+            )
+          ],
+          webId: 'system'
+        },
+        { parentCtx: ctx }
+      );
+    },
+    async detachAccessNeedGroup(ctx) {
+      const { accessNeedGroupUri } = ctx.params;
+      await this.actions.patch(
+        {
+          resourceUri: this.appActor.id,
+          triplesToRemove: [
+            triple(
+              namedNode(this.appActor.id),
+              namedNode('http://www.w3.org/ns/solid/interop#hasAccessNeedGroup'),
+              namedNode(accessNeedGroupUri)
+            )
+          ],
+          webId: 'system'
+        },
+        { parentCtx: ctx }
+      );
+    }
   }
 };

--- a/packages/app/services/registration/actors.js
+++ b/packages/app/services/registration/actors.js
@@ -151,6 +151,40 @@ module.exports = {
         },
         { parentCtx: ctx }
       );
+    },
+    async attachAccessDescriptionSet(ctx) {
+      const { accessDescriptionSetUri } = ctx.params;
+      await this.actions.patch(
+        {
+          resourceUri: this.appActor.id,
+          triplesToAdd: [
+            triple(
+              namedNode(this.appActor.id),
+              namedNode('http://www.w3.org/ns/solid/interop#hasAccessDescriptionSet'),
+              namedNode(accessDescriptionSetUri)
+            )
+          ],
+          webId: 'system'
+        },
+        { parentCtx: ctx }
+      );
+    },
+    async detachAccessDescriptionSet(ctx) {
+      const { accessDescriptionSetUri } = ctx.params;
+      await this.actions.patch(
+        {
+          resourceUri: this.appActor.id,
+          triplesToRemove: [
+            triple(
+              namedNode(this.appActor.id),
+              namedNode('http://www.w3.org/ns/solid/interop#hasAccessDescriptionSet'),
+              namedNode(accessDescriptionSetUri)
+            )
+          ],
+          webId: 'system'
+        },
+        { parentCtx: ctx }
+      );
     }
   }
 };

--- a/packages/app/services/registration/app-registrations.js
+++ b/packages/app/services/registration/app-registrations.js
@@ -1,5 +1,8 @@
 const { ControlledContainerMixin, arrayOf } = require('@semapps/ldp');
 
+/**
+ * Mirror container for application registrations
+ */
 module.exports = {
   name: 'app-registrations',
   mixins: [ControlledContainerMixin],

--- a/packages/app/services/registration/data-grants.js
+++ b/packages/app/services/registration/data-grants.js
@@ -1,5 +1,8 @@
 const { ControlledContainerMixin } = require('@semapps/ldp');
 
+/**
+ * Mirror container for data grants which have been granted to the app
+ */
 module.exports = {
   name: 'data-grants',
   mixins: [ControlledContainerMixin],

--- a/packages/app/services/registration/registration.js
+++ b/packages/app/services/registration/registration.js
@@ -4,7 +4,7 @@ const { arrayOf } = require('@semapps/ldp');
 const { MIME_TYPES } = require('@semapps/mime-types');
 
 module.exports = {
-  name: 'app.registration',
+  name: 'registration',
   mixins: [ActivitiesHandlerMixin],
   activities: {
     createAppRegistration: {

--- a/packages/app/utils.js
+++ b/packages/app/utils.js
@@ -1,3 +1,5 @@
+const { arrayOf } = require('@semapps/ldp');
+
 const objectDepth = o => (Object(o) === o ? 1 + Math.max(-1, ...Object.values(o).map(objectDepth)) : 0);
 
 const stream2buffer = stream => {
@@ -9,7 +11,12 @@ const stream2buffer = stream => {
   });
 };
 
+// Return true if all elements of a1 can be found on a2. Order does not matter.
+const arraysEqual = (a1, a2) =>
+  arrayOf(a1).length === arrayOf(a2).length && arrayOf(a1).every(i => arrayOf(a2).includes(i));
+
 module.exports = {
   objectDepth,
-  stream2buffer
+  stream2buffer,
+  arraysEqual
 };

--- a/packages/ontologies/oidc.json
+++ b/packages/ontologies/oidc.json
@@ -17,12 +17,6 @@
     },
     "oidc:redirect_uris": {
       "@type": "@id"
-    },
-    "oidc:require_auth_time": {
-      "@type": "xsd:boolean"
-    },
-    "oidc:default_max_age": {
-      "@type": "xsd:integer"
     }
   }
 }


### PR DESCRIPTION
First step toward app upgrade (https://github.com/activitypods/activitypods/issues/102)

When the app settings change:
- Update Application resource
- Update AccessNeed and AccessNeedGroups resources
- Update ClassDescription and AccessDescriptionSet resources

Since all these resources (except the Application) are immutable, changing any of them will necessarily create new URIs, and it will reflect on the Application resource. Looking at the `dc:modified` predicate will thus be a simple way to identity when an application has been changed.