### PR TITLE
chore: remove legacy `actorsKeyPairDir` setting from key service

### DIFF
--- a/pod-provider/backend/services/core/keys.js
+++ b/pod-provider/backend/services/core/keys.js
@@ -4,7 +4,6 @@ const { KeysService } = require('@semapps/crypto');
 module.exports = {
   mixins: [KeysService],
   settings: {
-    actorsKeyPairsDir: path.resolve(__dirname, '../../actors'), // Not necessary anymore ?
     podProvider: true
   }
 };


### PR DESCRIPTION
For new setups, we don't need the directory and setting anymore.
If I understand correctly, there are no legacy configurations using the refactored pod-provider setup, right @srosset81?
Depends on https://github.com/assemblee-virtuelle/semapps/pull/1315