### PR TITLE
Fix broken link

### DIFF
--- a/docs/src/content/docs/app-framework/backend/application-registration.md
+++ b/docs/src/content/docs/app-framework/backend/application-registration.md
@@ -4,7 +4,7 @@ sidebar:
   order: 1
 ---
 
-Application registration is a complex process [as can be read here](../../design/application-interoperability/). Fortunately, we handle it behind the scene so you have nothing to do except configuring a few settings.
+Application registration is a complex process [as can be read here](../../architecture/application-interoperability/). Fortunately, we handle it behind the scene so you have nothing to do except configuring a few settings.
 
 ## `AppService`
 


### PR DESCRIPTION
I have noticed this broken link, but there are probably more. You may consider using [markdownlint](https://github.com/DavidAnson/markdownlint) with the [markdownlint-rule-relative-links](https://github.com/theoludwig/markdownlint-rule-relative-links) rule to avoid this in the future.