### PR TITLE
Show user error notification, if user authorization agent not found

### DIFF
--- a/app-framework/react/src/components/LoginPage.tsx
+++ b/app-framework/react/src/components/LoginPage.tsx
@@ -73,15 +73,19 @@ const LoginPage: FunctionComponent<Props> = ({ text, clientId, customPodProvider
       const token = localStorage.getItem('token');
       if (token) {
         const payload = jwtDecode(token) as SolidOIDCToken;
-        registerApp(clientId, payload?.webid).then(appRegistrationUri => {
-          if (appRegistrationUri) setIsRegistered(true);
-        });
+        registerApp(clientId, payload?.webid)
+          .then(appRegistrationUri => {
+            if (appRegistrationUri) setIsRegistered(true);
+          })
+          .catch(error => {
+            notify(error.message, { type: 'error' });
+          });
       }
     } else if (searchParams.has('logout')) {
       // Immediately logout if required
       logout({ redirectUrl });
     }
-  }, [searchParams, login, registerApp, clientId, setIsRegistered, logout, redirectUrl]);
+  }, [searchParams, login, registerApp, clientId, setIsRegistered, notify, logout, redirectUrl]);
 
   useEffect(() => {
     if (!isIdentityLoading && identity?.id && isRegistered) {

--- a/app-framework/react/src/hooks/useRegisterApp.ts
+++ b/app-framework/react/src/hooks/useRegisterApp.ts
@@ -31,6 +31,8 @@ const useRegisterApp = () => {
           redirectUrl.searchParams.append('client_id', clientId);
           window.location.href = redirectUrl.toString();
         }
+      } else {
+        throw new Error(`apods.error.user_authorization_agent_not_found`);
       }
     },
     [dataProvider]

--- a/app-framework/react/src/messages/en.ts
+++ b/app-framework/react/src/messages/en.ts
@@ -21,7 +21,8 @@ export default {
       app_status_unavailable: 'Unable to check app status',
       app_offline: 'The app backend is offline',
       app_not_registered: 'The app is not registered',
-      app_not_listening: 'The app is not listening to %{uri}'
+      app_not_listening: 'The app is not listening to %{uri}',
+      user_authorization_agent_not_found: 'User authorization agent not found'
     },
     user_menu: {
       network: 'My network',


### PR DESCRIPTION
Hello everyone,
this is my first contribution here :)

I tested it locally and it showed me the error notification, after I removed the interop:hasAuthorizationAgent triple from the dataset manually in my local setup. 
The relevant translation strings seem to be maintained in another project (semapps/auth-provider), where I will link the according PR here.

closes #394 