### PR TITLE
Docs: Fix accidental double backtick in authentication.md

### DIFF
--- a/docs/src/content/docs/architecture/authentication.md
+++ b/docs/src/content/docs/architecture/authentication.md
@@ -21,7 +21,7 @@ There is now a [proposal](https://solid.github.io/httpsig/) to integrate HTTP si
 
 The ActivityPub specification [mentions](https://www.w3.org/TR/activitypub/#actor-objects) a `as:proxyUrl` predicate (included in the `as:endpoint` predicate of the actor) with the following description:
 
-> Endpoint URI so this actor's clients may access remote ActivityStreams objects which require authentication to access. To use this endpoint, the client posts an `x-www-form-urlencoded`` id parameter with the value being the `id` of the requested ActivityStreams object.
+> Endpoint URI so this actor's clients may access remote ActivityStreams objects which require authentication to access. To use this endpoint, the client posts an `x-www-form-urlencoded` id parameter with the value being the `id` of the requested ActivityStreams object.
 
 We have implemented this endpoint, and we have extended it for non-GET methods using the `multipart/form-data` Content-Type.
 


### PR DESCRIPTION
Just noticed this whilst reading the docs: 
<img width="808" alt="Screenshot 2025-04-11 at 19 00 17" src="https://github.com/user-attachments/assets/2d573414-399d-4021-a756-6be21f779bb2" />

It's clearly not formatted correctly, so this removes the extra backtick and fixes that.