### PR TITLE
fix: replace broken permission fuseki docker image

### DIFF
--- a/pod-provider/docker-compose-test.yml
+++ b/pod-provider/docker-compose-test.yml
@@ -1,6 +1,6 @@
 services:
   fuseki_test:
-    image: stain/jena-fuseki:5.1.0
+    image: secoresearch/fuseki:5.5.0
     volumes:
       - ./data/fuseki_test:/fuseki:z
     ports:

--- a/pod-provider/docker-compose.yml
+++ b/pod-provider/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   fuseki:
-    image: stain/jena-fuseki:5.1.0
+    image: secoresearch/fuseki:5.5.0
     container_name: fuseki
     volumes:
       - ./data/fuseki:/fuseki:z
@@ -28,7 +28,7 @@ services:
       - '6379:6379'
     volumes:
       - ./data/redis:/data:z
-    command: [ 'redis-server', '--appendonly', 'yes' ]
+    command: ['redis-server', '--appendonly', 'yes']
 
   arena:
     image: activitypods/arena


### PR DESCRIPTION
The fusek 5 docker image is broken. The shiro.ini file had the wrong permission. The docker repo does not seem to be well-maintained.

The docker-compose files are now using secoresearch/fuseki:5.5.0`.